### PR TITLE
Remove Authorization header when get access token

### DIFF
--- a/lib/shutterstock-client.rb
+++ b/lib/shutterstock-client.rb
@@ -55,6 +55,7 @@ module ShutterstockAPI
 
     def get_access_token
       options=@options
+      options[:headers].delete('Authorization')
       options[:body] = { client_id: config.client_id, client_secret: config.client_secret, grant_type: 'client_credentials'}
       response = self.class.post( "#{config.api_url}/oauth/access_token", options )
 


### PR DESCRIPTION
新しくaccess tokenをとるときは、Authorizationヘッダーを消してリクエストを投げます